### PR TITLE
Don't log the cancellation exception.

### DIFF
--- a/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowWorkerService.java
+++ b/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowWorkerService.java
@@ -40,6 +40,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
 import static org.gridsuite.loadflow.server.service.LoadFlowRunContext.buildParameters;
+import static org.gridsuite.loadflow.server.service.NotificationService.CANCEL_MESSAGE;
 import static org.gridsuite.loadflow.server.service.NotificationService.FAIL_MESSAGE;
 
 /**
@@ -143,6 +144,7 @@ public class LoadFlowWorkerService {
     private void cleanLoadFlowResultsAndPublishCancel(UUID resultUuid, String receiver) {
         resultRepository.delete(resultUuid);
         notificationService.publishStop(resultUuid, receiver);
+        LOGGER.info(CANCEL_MESSAGE + " (resultUuid='{}')", resultUuid);
     }
 
     private static LoadingLimits.TemporaryLimit getBranchLimitViolationAboveCurrentValue(Branch<?> branch, LimitViolationInfos violationInfo) {
@@ -270,8 +272,8 @@ public class LoadFlowWorkerService {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } catch (Exception e) {
-                LOGGER.error(FAIL_MESSAGE, e);
                 if (!(e instanceof CancellationException)) {
+                    LOGGER.error(FAIL_MESSAGE, e);
                     notificationService.publishFail(resultContext.getResultUuid(), resultContext.getRunContext().getReceiver(), e.getMessage(), resultContext.getRunContext().getUserId());
                     resultRepository.delete(resultContext.getResultUuid());
                 }


### PR DESCRIPTION
 Get a consistent implementation with respect to other calculation services, log a cancellation message instead.