### PR TITLE
Flush network when status is PARTIALLY_CONVERGED or FULLY_CONVERGED

### DIFF
--- a/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowObserver.java
+++ b/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowObserver.java
@@ -33,6 +33,6 @@ public class LoadFlowObserver extends AbstractComputationObserver<LoadFlowResult
 
     @Override
     protected String getResultStatus(LoadFlowResult res) {
-        return res != null && res.isPartiallyConverged() ? "OK" : "NOK";
+        return res != null && !res.isFailed() ? "OK" : "NOK";
     }
 }

--- a/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowWorkerService.java
+++ b/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowWorkerService.java
@@ -59,7 +59,7 @@ public class LoadFlowWorkerService extends AbstractWorkerService<LoadFlowResult,
     @Override
     protected LoadFlowResult run(Network network, AbstractResultContext<LoadFlowRunContext> resultContext) throws Exception {
         LoadFlowResult result = super.run(network, resultContext);
-        if (result != null && result.isPartiallyConverged()) {
+        if (result != null && !result.isFailed()) {
             // flush each network in the network store
             observer.observe("network.save", resultContext.getRunContext(), () -> networkStoreService.flush(network));
         }


### PR DESCRIPTION
In the current implementation, the network is flushed after the loadflow computation only when the result is partially converged.  
The network should also be flushed when the result is fully converged. This currently lead to inconsistent results in the application.