### PR TITLE
Fix update of specific parameters

### DIFF
--- a/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowRunContext.java
+++ b/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowRunContext.java
@@ -7,6 +7,7 @@
 package org.gridsuite.loadflow.server.service;
 
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.extensions.Extension;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowProvider;
@@ -35,8 +36,9 @@ public class LoadFlowRunContext extends AbstractComputationRunContext<LoadFlowPa
         LoadFlowProvider lfProvider = LoadFlowProvider.findAll().stream()
                 .filter(p -> p.getName().equals(provider))
                 .findFirst().orElseThrow(() -> new PowsyblException("LoadFLow provider not found " + provider));
-        Extension<LoadFlowParameters> extension = lfProvider.loadSpecificParameters(parameters.specificParameters())
+        Extension<LoadFlowParameters> extension = lfProvider.loadSpecificParameters(PlatformConfig.defaultConfig())
                 .orElseThrow(() -> new PowsyblException("Cannot add specific loadflow parameters with provider " + provider));
+        lfProvider.updateSpecificParameters(extension, parameters.specificParameters());
         params.addExtension((Class) extension.getClass(), extension);
         return params;
     }


### PR DESCRIPTION
The methods load(Map<String, String> properties) does not account for the PlatformConfig, see for example:
https://github.com/powsybl/powsybl-open-loadflow/blob/6e2d28af8148ec9a7ee7d5c3a32f94edba75629f/src/main/java/com/powsybl/openloadflow/OpenLoadFlowParameters.java#L1255-L1257
So we first load the PlatformConfig and then update with the specific parameters provided by the user.