### PR TITLE
Fix update of specific parameters for Dynaflow

### DIFF
--- a/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowRunContext.java
+++ b/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowRunContext.java
@@ -38,8 +38,8 @@ public class LoadFlowRunContext extends AbstractComputationRunContext<LoadFlowPa
                 .findFirst().orElseThrow(() -> new PowsyblException("LoadFLow provider not found " + provider));
         Extension<LoadFlowParameters> specificParametersExtension = lfProvider.loadSpecificParameters(PlatformConfig.defaultConfig())
                 .orElseThrow(() -> new PowsyblException("Cannot add specific loadflow parameters with provider " + provider));
-        lfProvider.updateSpecificParameters(specificParametersExtension, parameters.specificParameters());
         params.addExtension((Class) specificParametersExtension.getClass(), specificParametersExtension);
+        lfProvider.updateSpecificParameters(specificParametersExtension, parameters.specificParameters());
         return params;
     }
 


### PR DESCRIPTION
When using updateSpecificParameters() in DynaFlow, the extension needs to be associated to a LoadFlowParameters as there is a getExtendable() in the Dynaflow implementation: https://github.com/powsybl/powsybl-dynawo/blob/d878c7892b25e1fe18800bc87d6a08addd95ce12/dynaflow/src/main/java/com/powsybl/dynaflow/DynaFlowProvider.java#L174
Otherwise, we get this error: `Cannot invoke "com.powsybl.loadflow.LoadFlowParameters.getExtension(java.lang.Class)" because "parameters" is null`. In the other providers, it works fine.
In this PR, we first associate the extension to the LoadFlowParameters and then update the specific parameters with the user values. 