### PR TITLE
Upgrade network-store to 1.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,8 @@
         Caused by: java.io.InvalidClassException: org.antlr.v4.runtime.atn.ATN; Could not deserialize ATN with version 4 (expected 3).
         -->
         <antlr4.version>4.10.1</antlr4.version>
+        <!-- FIXME: powsybl-network-store modules'version is overloaded in the dependencies section.The overloads and this property below have to be removed at next powsybl-ws-dependencies.version upgrade -->
+        <powsybl-network-store.version>1.16.0</powsybl-network-store.version>
     </properties>
 
     <build>
@@ -91,6 +93,24 @@
     <dependencyManagement>
         <dependencies>
             <!-- overrides of imports -->
+            <!-- FIXME: to be removed at next powsybl-ws-dependencies upgrade  -->
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-network-store-client</artifactId>
+                <version>${powsybl-network-store.version}</version>
+            </dependency>
+            <!-- FIXME: to be removed at next powsybl-ws-dependencies upgrade  -->
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-network-store-iidm-impl</artifactId>
+                <version>${powsybl-network-store.version}</version>
+            </dependency>
+            <!-- FIXME: to be removed at next powsybl-ws-dependencies upgrade  -->
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-network-store-model</artifactId>
+                <version>${powsybl-network-store.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4</artifactId>

--- a/src/test/java/org/gridsuite/loadflow/server/LoadFlowControllerTest.java
+++ b/src/test/java/org/gridsuite/loadflow/server/LoadFlowControllerTest.java
@@ -291,8 +291,10 @@ public class LoadFlowControllerTest {
     @Test
     public void testGetEnumValues() throws Exception {
         LoadFlow.Runner runner = Mockito.mock(LoadFlow.Runner.class);
-        try (MockedStatic<LoadFlow> loadFlowMockedStatic = Mockito.mockStatic(LoadFlow.class)) {
+        try (MockedStatic<LoadFlow> loadFlowMockedStatic = Mockito.mockStatic(LoadFlow.class);
+             MockedStatic<Security> securityMockedStatic = Mockito.mockStatic(Security.class)) {
             loadFlowMockedStatic.when(() -> LoadFlow.find(any())).thenReturn(runner);
+            securityMockedStatic.when(() -> Security.checkLimitsDc(any(), any(), anyDouble())).thenReturn(LimitViolationsMock.limitViolations);
 
             Mockito.when(runner.runAsync(eq(network), eq(VARIANT_2_ID), eq(executionService.getComputationManager()),
                             any(LoadFlowParameters.class), any(ReportNode.class)))
@@ -309,36 +311,40 @@ public class LoadFlowControllerTest {
             Message<byte[]> resultMessage = output.receive(1000, "loadflow.result");
             assertEquals(RESULT_UUID.toString(), resultMessage.getHeaders().get("resultUuid"));
             assertEquals("me", resultMessage.getHeaders().get("receiver"));
+
+            // get loadflow limit types
+            MvcResult mvcResult = mockMvc.perform(get("/" + VERSION + "/results/{resultUuid}/limit-types", RESULT_UUID))
+                    .andExpectAll(
+                            status().isOk(),
+                            content().contentType(MediaType.APPLICATION_JSON)
+                    ).andReturn();
+            List<LimitViolationType> limitTypes = mapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() {
+            });
+            assertEquals(0, limitTypes.size());
+
+            // get loadflow branch sides
+            mvcResult = mockMvc.perform(get("/" + VERSION + "/results/{resultUuid}/branch-sides", RESULT_UUID))
+                    .andExpectAll(
+                            status().isOk(),
+                            content().contentType(MediaType.APPLICATION_JSON)
+                    ).andReturn();
+            List<TwoSides> sides = mapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() {
+            });
+            assertEquals(2, sides.size());
+            assertTrue(sides.contains(TwoSides.ONE));
+            assertTrue(sides.contains(TwoSides.TWO));
+
+            // get loadflow computing status
+            mvcResult = mockMvc.perform(get("/" + VERSION + "/results/{resultUuid}/computation-status", RESULT_UUID))
+                    .andExpectAll(
+                            status().isOk(),
+                            content().contentType(MediaType.APPLICATION_JSON)
+                    ).andReturn();
+            List<LoadFlowResult.ComponentResult.Status> status = mapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() {
+            });
+            assertEquals(1, status.size());
+            assertTrue(status.contains(LoadFlowResult.ComponentResult.Status.CONVERGED));
         }
-
-        // get loadflow limit types
-        MvcResult mvcResult = mockMvc.perform(get("/" + VERSION + "/results/{resultUuid}/limit-types", RESULT_UUID))
-                .andExpectAll(
-                        status().isOk(),
-                        content().contentType(MediaType.APPLICATION_JSON)
-                ).andReturn();
-        List<LimitViolationType> limitTypes = mapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() { });
-        assertEquals(0, limitTypes.size());
-
-        // get loadflow branch sides
-        mvcResult = mockMvc.perform(get("/" + VERSION + "/results/{resultUuid}/branch-sides", RESULT_UUID))
-                .andExpectAll(
-                        status().isOk(),
-                        content().contentType(MediaType.APPLICATION_JSON)
-                ).andReturn();
-        List<TwoSides> sides = mapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() { });
-        assertEquals(1, sides.size());
-        assertTrue(sides.contains(TwoSides.ONE));
-
-        // get loadflow computing status
-        mvcResult = mockMvc.perform(get("/" + VERSION + "/results/{resultUuid}/computation-status", RESULT_UUID))
-                .andExpectAll(
-                        status().isOk(),
-                        content().contentType(MediaType.APPLICATION_JSON)
-                ).andReturn();
-        List<LoadFlowResult.ComponentResult.Status> status = mapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() { });
-        assertEquals(1, status.size());
-        assertTrue(status.contains(LoadFlowResult.ComponentResult.Status.CONVERGED));
     }
 
     @Test


### PR DESCRIPTION
* Upgrade network-store version to 1.16.0
* After upgrade, testGetEnumValues() fails because of https://github.com/powsybl/powsybl-network-store/pull/427, the value of V in the busView changed in the test network. When the network is constructed, the setV() also sets V in the busView in the test network while it did not before. This yields different loadflow results. It seems to be the expected new behavior from the PR description. 
--> In other test cases, we mock the limit violations results for robustness, I propose the same for this test to improve robustness and test only what we want to test (which here is the endpoint that returns the sides in results).