### PR TITLE
Refactor: Simplification of `GlobalStatusRepository` and `ResultRepository`

### DIFF
--- a/src/main/java/org/gridsuite/loadflow/server/repositories/GlobalStatusRepository.java
+++ b/src/main/java/org/gridsuite/loadflow/server/repositories/GlobalStatusRepository.java
@@ -17,8 +17,4 @@ import java.util.UUID;
  */
 @Repository
 public interface GlobalStatusRepository extends JpaRepository<GlobalStatusEntity, UUID> {
-    GlobalStatusEntity findByResultUuid(UUID resultUuid);
-
-    void deleteByResultUuid(UUID resultUuid);
-
 }

--- a/src/main/java/org/gridsuite/loadflow/server/repositories/ResultRepository.java
+++ b/src/main/java/org/gridsuite/loadflow/server/repositories/ResultRepository.java
@@ -10,7 +10,6 @@ import org.gridsuite.loadflow.server.entities.LoadFlowResultEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -18,7 +17,4 @@ import java.util.UUID;
  */
 @Repository
 public interface ResultRepository extends JpaRepository<LoadFlowResultEntity, UUID> {
-    Optional<LoadFlowResultEntity> findByResultUuid(UUID resultUuid);
-
-    void deleteByResultUuid(UUID resultUuid);
 }

--- a/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowResultService.java
+++ b/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowResultService.java
@@ -207,13 +207,13 @@ public class LoadFlowResultService extends AbstractComputationResultService<Load
     @Transactional
     public void delete(UUID resultUuid) {
         Objects.requireNonNull(resultUuid);
-        globalStatusRepository.deleteByResultUuid(resultUuid);
-        resultRepository.deleteByResultUuid(resultUuid);
+        globalStatusRepository.deleteById(resultUuid);
+        resultRepository.deleteById(resultUuid);
     }
 
     public Optional<LoadFlowResultEntity> findResults(UUID resultUuid) {
         Objects.requireNonNull(resultUuid);
-        return resultRepository.findByResultUuid(resultUuid);
+        return resultRepository.findById(resultUuid);
     }
 
     @Override
@@ -227,8 +227,8 @@ public class LoadFlowResultService extends AbstractComputationResultService<Load
     @Transactional(readOnly = true)
     public LoadFlowStatus findStatus(UUID resultUuid) {
         Objects.requireNonNull(resultUuid);
-        GlobalStatusEntity globalEntity = globalStatusRepository.findByResultUuid(resultUuid);
-        return globalEntity != null ? globalEntity.getStatus() : null;
+        Optional<GlobalStatusEntity> globalEntity = globalStatusRepository.findById(resultUuid);
+        return globalEntity.map(GlobalStatusEntity::getStatus).orElse(null);
     }
 
     @Override

--- a/src/test/java/org/gridsuite/loadflow/server/LoadFlowControllerTest.java
+++ b/src/test/java/org/gridsuite/loadflow/server/LoadFlowControllerTest.java
@@ -1074,7 +1074,7 @@ public class LoadFlowControllerTest {
             .andExpect(status().isOk())
             .andReturn();
         assertEquals(LoadFlowStatus.RUNNING, mapper.readValue(result.getResponse().getContentAsString(), LoadFlowStatus.class));
-        assertEquals(LoadFlowStatus.RUNNING, globalStatusRepository.findByResultUuid(resultUuid).getStatus());
+        assertEquals(LoadFlowStatus.RUNNING, globalStatusRepository.findById(resultUuid).get().getStatus());
     }
 
     @Test


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
refactor(): `resultUuid` is the Id of `LoadFlowResultEntity` and `GlobalStatusEntity` then no need for specific methods in Jpa Repositories


