### PR TITLE
Support for three sides in branch sides retrieval

### DIFF
--- a/src/main/java/org/gridsuite/loadflow/server/LoadFlowController.java
+++ b/src/main/java/org/gridsuite/loadflow/server/LoadFlowController.java
@@ -7,7 +7,7 @@
 package org.gridsuite.loadflow.server;
 
 import com.powsybl.contingency.violations.LimitViolationType;
-import com.powsybl.iidm.network.TwoSides;
+import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.loadflow.LoadFlowResult.ComponentResult.Status;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -207,7 +207,7 @@ public class LoadFlowController {
     @GetMapping(value = "/results/{resultUuid}/branch-sides", produces = APPLICATION_JSON_VALUE)
     @Operation(summary = "Get the list of branch sides values")
     @ApiResponses(@ApiResponse(responseCode = "200", description = "List of branch sides values by result"))
-    public ResponseEntity<List<TwoSides>> getBranchSides(@Parameter(description = "Result UUID") @PathVariable("resultUuid") UUID resultUuid) {
+    public ResponseEntity<List<ThreeSides>> getBranchSides(@Parameter(description = "Result UUID") @PathVariable("resultUuid") UUID resultUuid) {
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(loadFlowResultService.getBranchSides(resultUuid));
     }
 

--- a/src/main/java/org/gridsuite/loadflow/server/repositories/LimitViolationRepository.java
+++ b/src/main/java/org/gridsuite/loadflow/server/repositories/LimitViolationRepository.java
@@ -7,7 +7,7 @@
 package org.gridsuite.loadflow.server.repositories;
 
 import com.powsybl.contingency.violations.LimitViolationType;
-import com.powsybl.iidm.network.TwoSides;
+import com.powsybl.iidm.network.ThreeSides;
 import org.gridsuite.loadflow.server.entities.LimitViolationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -33,5 +33,5 @@ public interface LimitViolationRepository extends JpaRepository<LimitViolationEn
     @Query(value = "SELECT distinct l.side from LimitViolationEntity as l " +
             "where l.loadFlowResult.resultUuid = :resultUuid AND l.side != ''" +
             "order by l.side")
-    List<TwoSides> findBranchSides(UUID resultUuid);
+    List<ThreeSides> findBranchSides(UUID resultUuid);
 }

--- a/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowResultService.java
+++ b/src/main/java/org/gridsuite/loadflow/server/service/LoadFlowResultService.java
@@ -9,7 +9,7 @@ package org.gridsuite.loadflow.server.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.contingency.violations.LimitViolationType;
-import com.powsybl.iidm.network.TwoSides;
+import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.loadflow.LoadFlowResult;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
@@ -373,7 +373,7 @@ public class LoadFlowResultService extends AbstractComputationResultService<Load
         return limitViolationRepository.findLimitTypes(resultUuid);
     }
 
-    public List<TwoSides> getBranchSides(UUID resultUuid) {
+    public List<ThreeSides> getBranchSides(UUID resultUuid) {
         Objects.requireNonNull(resultUuid);
         return limitViolationRepository.findBranchSides(resultUuid);
     }

--- a/src/test/java/org/gridsuite/loadflow/server/LoadFlowControllerTest.java
+++ b/src/test/java/org/gridsuite/loadflow/server/LoadFlowControllerTest.java
@@ -416,11 +416,12 @@ public class LoadFlowControllerTest {
                             status().isOk(),
                             content().contentType(MediaType.APPLICATION_JSON)
                     ).andReturn();
-            List<TwoSides> sides = mapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() {
+            List<ThreeSides> sides = mapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() {
             });
-            assertEquals(2, sides.size());
-            assertTrue(sides.contains(TwoSides.ONE));
-            assertTrue(sides.contains(TwoSides.TWO));
+            assertEquals(3, sides.size());
+            assertTrue(sides.contains(ThreeSides.ONE));
+            assertTrue(sides.contains(ThreeSides.TWO));
+            assertTrue(sides.contains(ThreeSides.THREE));
 
             // get loadflow computing status
             mvcResult = mockMvc.perform(get("/" + VERSION + "/results/{resultUuid}/computation-status", RESULT_UUID))
@@ -985,7 +986,7 @@ public class LoadFlowControllerTest {
                 new LimitViolation("NHV1_NHV2_1", "lineName1", LimitViolationType.CURRENT, "limit1", 60, 1500, 0.7F, 1300, TwoSides.TWO),
                 new LimitViolation("NHV1_NHV2_1", "lineName2", LimitViolationType.CURRENT, "limit2", 60, 1500, 0.7F, 1000, TwoSides.TWO),
                 new LimitViolation("NHV1_NHV2_2", "lineName3", LimitViolationType.CURRENT, "limit3", 300, 900, 0.7F, 1000, TwoSides.ONE),
-                new LimitViolation("NHV1_NHV2_2", "lineName4", LimitViolationType.CURRENT, "limit4", 300, 900, 0.7F, 1000, TwoSides.TWO));
+                new LimitViolation("NHV1_NHV2_2", "lineName4", LimitViolationType.CURRENT, "limit4", 300, 900, 0.7F, 1000, ThreeSides.THREE));
     }
 
     @Test

--- a/src/test/java/org/gridsuite/loadflow/server/LoadFlowControllerTest.java
+++ b/src/test/java/org/gridsuite/loadflow/server/LoadFlowControllerTest.java
@@ -382,7 +382,7 @@ public class LoadFlowControllerTest {
         try (MockedStatic<LoadFlow> loadFlowMockedStatic = Mockito.mockStatic(LoadFlow.class);
              MockedStatic<Security> securityMockedStatic = Mockito.mockStatic(Security.class)) {
             loadFlowMockedStatic.when(() -> LoadFlow.find(any())).thenReturn(runner);
-            securityMockedStatic.when(() -> Security.checkLimitsDc(any(), any(), anyDouble())).thenReturn(LimitViolationsMock.limitViolations);
+            securityMockedStatic.when(() -> Security.checkLimitsDc(any(), any(), anyDouble())).thenReturn(LimitViolationsMock.limitViolationsWithThreeSides);
 
             Mockito.when(runner.runAsync(eq(network), eq(VARIANT_2_ID), any(LoadFlowRunParameters.class)))
                     .thenReturn(CompletableFuture.completedFuture(LoadFlowResultMock.RESULT));
@@ -986,7 +986,11 @@ public class LoadFlowControllerTest {
                 new LimitViolation("NHV1_NHV2_1", "lineName1", LimitViolationType.CURRENT, "limit1", 60, 1500, 0.7F, 1300, TwoSides.TWO),
                 new LimitViolation("NHV1_NHV2_1", "lineName2", LimitViolationType.CURRENT, "limit2", 60, 1500, 0.7F, 1000, TwoSides.TWO),
                 new LimitViolation("NHV1_NHV2_2", "lineName3", LimitViolationType.CURRENT, "limit3", 300, 900, 0.7F, 1000, TwoSides.ONE),
-                new LimitViolation("NHV1_NHV2_2", "lineName4", LimitViolationType.CURRENT, "limit4", 300, 900, 0.7F, 1000, ThreeSides.THREE));
+                new LimitViolation("NHV1_NHV2_2", "lineName4", LimitViolationType.CURRENT, "limit4", 300, 900, 0.7F, 1000, TwoSides.TWO));
+        static List<LimitViolation> limitViolationsWithThreeSides = List.of(
+                new LimitViolation("NHV1_NHV2_1", "lineName1", LimitViolationType.CURRENT, "limit1", 60, 1500, 0.7F, 1300, TwoSides.TWO),
+                new LimitViolation("NHV1_NHV2_2", "lineName3", LimitViolationType.CURRENT, "limit3", 300, 900, 0.7F, 1000, TwoSides.ONE),
+                new LimitViolation("THREE_WINDING_TRANSFORMER", "lineName4", LimitViolationType.CURRENT, "limit4", 300, 900, 0.7F, 1000, ThreeSides.THREE));
     }
 
     @Test


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
In the current implementation, if there is a violation on a side 3, it's correctly saved in the database but the endpoint getBranchSides returns an error because it can't cast side 3 to a TwoSides. 
This PR fixes that by .


